### PR TITLE
Feature/alejandro miguez.add mfa support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ## 0.4.0
 ### Changes:
-- Added `callback_mfa` field to the record alongside existing `callback_mod`
-- Updated type definitions to include callback_mfa => {module(), atom(), list()}
-- Implemented validate_callback/1 function that handles both patterns
-- Added call_callback/3 helper function that routes calls appropriately:
-    - For callback_mod: calls Module:Function(Args)
-    - For callback_mfa: calls Module:Fun(ExtraArgs ++ [Function, Args])
-- Updated all callback invocations (send, broadcast, on_merge) to use the new pattern
-- Maintained full backward compatibility
+- Added `callback_args` field to support extra arguments passed to callback functions
+- Updated type definitions to include callback_args => list()
+- Modified call_callback/3 function to prepend extra args to callback function arguments
+- Maintained full backward compatibility with existing callback_mod implementations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,12 @@
 # CHANGELOG
+
+## 0.4.0
+### Changes:
+- Added `callback_mfa` field to the record alongside existing `callback_mod`
+- Updated type definitions to include callback_mfa => {module(), atom(), list()}
+- Implemented validate_callback/1 function that handles both patterns
+- Added call_callback/3 helper function that routes calls appropriately:
+    - For callback_mod: calls Module:Function(Args)
+    - For callback_mfa: calls Module:Fun(ExtraArgs ++ [Function, Args])
+- Updated all callback invocations (send, broadcast, on_merge) to use the new pattern
+- Maintained full backward compatibility

--- a/rebar.config
+++ b/rebar.config
@@ -46,7 +46,7 @@
 
 
 {relx, [
-    {release, {bondy_mst, "0.3.1"}, [
+    {release, {bondy_mst, "0.4.0"}, [
         %% Erlang
         compiler,
         crypto,

--- a/rebar.config
+++ b/rebar.config
@@ -76,7 +76,7 @@
 {profiles, [
     {test, [
         {relx, [
-            {release, {bondy_mst, "0.3.1"}, [
+            {release, {bondy_mst, "0.4.0"}, [
                 %% Erlang
                 compiler,
                 crypto,

--- a/src/bondy_mst.app.src
+++ b/src/bondy_mst.app.src
@@ -1,6 +1,6 @@
 {application, bondy_mst,
  [{description, "An OTP application"},
-  {vsn, "0.3.5"},
+  {vsn, "0.4.0"},
   {registered, []},
   {mod, {bondy_mst_app, []}},
   {applications,

--- a/src/bondy_mst.erl
+++ b/src/bondy_mst.erl
@@ -652,7 +652,7 @@ when is_list(Arg0) orelse is_integer(Arg0) ->
                         Arg0
                 end,
                 {Store, Meta} = bondy_mst_store:gc(Store0, Arg),
-                ?LOG_NOTICE(#{
+                ?LOG_DEBUG(#{
                     description => "Garbage collection completed",
                     name => maps:get(name, Meta, <<"unknown">>),
                     freed_count => maps:get(freed_count, Meta, 0),

--- a/src/bondy_mst.erl
+++ b/src/bondy_mst.erl
@@ -652,6 +652,12 @@ when is_list(Arg0) orelse is_integer(Arg0) ->
                         Arg0
                 end,
                 {Store, Meta} = bondy_mst_store:gc(Store0, Arg),
+                ?LOG_NOTICE(#{
+                    description => "Garbage collection completed",
+                    name => maps:get(name, Meta, <<"unknown">>),
+                    freed_count => maps:get(freed_count, Meta, 0),
+                    freed_bytes => maps:get(freed_bytes, Meta, 0)
+                }),
                 {T#?MODULE{store = Store}, Meta}
             end,
             bondy_mst_store:transaction(Store0, Fun)

--- a/src/bondy_mst_crdt.erl
+++ b/src/bondy_mst_crdt.erl
@@ -408,10 +408,9 @@ new(NodeId, Opts0) when
         [callback_mod, callback_args, max_merges, max_merges_per_root], Opts0
     ),
 
-    CallbackMod = validate_callback_mod(Opts),
     #?MODULE{
         node_id = NodeId,
-        callback_mod = CallbackMod,
+        callback_mod = validate_callback_mod(Opts),
         callback_args = key_value:get(callback_args, Opts, []),
         tree = Tree,
         consistency_model = key_value:get(consistency_model, Opts, causal),

--- a/src/bondy_mst_crdt.erl
+++ b/src/bondy_mst_crdt.erl
@@ -114,7 +114,8 @@ following callbacks:
 -record(?MODULE, {
     %% Normally node() but it can be a binary when testing
     node_id                         ::  node_id(),
-    callback_mod                    ::  module(),
+    callback_mod                    ::  module() | undefined,
+    callback_mfa                    ::  {module(), atom(), list()} | undefined,
     tree                            ::  bondy_mst:t(),
     consistency_model               ::  consistency_model(),
     %% Set it to false if you are using a peer service that handles gossip
@@ -190,7 +191,8 @@ following callbacks:
 -type opt()                 ::  bondy_mst:opt()
                                 | {max_merges, pos_integer()}
                                 | {max_merges_per_root, pos_integer()}
-                                | {callback_mod, module()}.
+                                | {callback_mod, module()}
+                                | {callback_mfa, {module(), atom(), list()}}.
 -type opts_map()            ::  #{
                                 %% bondy_mst
                                 store => bondy_mst_store:t(),
@@ -201,7 +203,8 @@ following callbacks:
                                 %%
                                 max_merges => pos_integer(),
                                 max_merges_per_root => pos_integer(),
-                                callback_mod => module()
+                                callback_mod => module(),
+                                callback_mfa => {module(), atom(), list()}
                             }.
 -type gossip()              ::  #gossip{}.
 -type get_cmd()             ::  #get{}.
@@ -364,6 +367,7 @@ values of a key. See `bondy_mst:merger()`
 * `comparator => bondy_mst:comparator()` - the function used by the tree to
 compare keys for sorting. See `bondy_mst:comparator()`
 * `callback_mod => module()` - The module implementing this modules' callbacks
+* `callback_mfa => {module(), atom(), list()}` - Alternative to callback_mod, specifies module, function, and extra arguments. The function will be called with the extra arguments plus the callback-specific arguments
 * `consistency_model => causal | eventual` - if `causal`, a full merge will be
 done on each update. If `eventual` full merges will only occur then triggered
 via `trigger/2`. Default is `causal`
@@ -396,12 +400,14 @@ new(NodeId, Opts0) when
 
     %% Configure the grove
     Opts = maps:with(
-        [callback_mod, max_merges, max_merges_per_root], Opts0
+        [callback_mod, callback_mfa, max_merges, max_merges_per_root], Opts0
     ),
 
+    {CallbackMod, CallbackMFA} = validate_callback(Opts),
     #?MODULE{
         node_id = NodeId,
-        callback_mod = validate_callback_mod(Opts),
+        callback_mod = CallbackMod,
+        callback_mfa = CallbackMFA,
         tree = Tree,
         consistency_model = key_value:get(consistency_model, Opts, causal),
         fwd_bcast = key_value:get(fwd_bcast, Opts, false),
@@ -604,7 +610,7 @@ trigger(#?MODULE{} = CRDT, Peer) when is_atom(Peer) ->
         key = undefined,
         value = undefined
     },
-    (CRDT#?MODULE.callback_mod):send(Peer, Event).
+    call_callback(CRDT, send, [Peer, Event]).
 
 
 ?DOC("""
@@ -769,12 +775,12 @@ handle(CRDT, #get{from = Peer, root = PeerRoot, set = Set}) ->
                     Set
                 ),
                 Msg = #put{from = CRDT#?MODULE.node_id, map = Map},
-                (CRDT#?MODULE.callback_mod):send(Peer, Msg);
+                call_callback(CRDT, send, [Peer, Msg]);
 
             false ->
                 %% We don't have all the pages, we reply a missing message
                 Msg = #missing{from = CRDT#?MODULE.node_id},
-                (CRDT#?MODULE.callback_mod):send(Peer, Msg)
+                call_callback(CRDT, send, [Peer, Msg])
         end,
 
     case PeerRoot == bondy_mst:root(Tree) of
@@ -855,20 +861,42 @@ handle(_CRDT, Msg) ->
 
 
 %% @private
-validate_callback_mod(Opts) ->
-    CallbackMod = maps:get(callback_mod, Opts),
+validate_callback(Opts) ->
+    case {maps:get(callback_mod, Opts, undefined), maps:get(callback_mfa, Opts, undefined)} of
+        {undefined, undefined} ->
+            error({badarg, "Either callback_mod or callback_mfa must be provided"});
+            
+        {CallbackMod, undefined} when is_atom(CallbackMod) ->
+            bondy_mst_utils:implements_behaviour(CallbackMod, ?MODULE)
+                orelse error(
+                    io_lib:format(
+                        "Expected ~p to implement behaviour ~p",
+                        [CallbackMod, ?MODULE]
+                    )
+                ),
+            {CallbackMod, undefined};
+            
+        {undefined, {Mod, Fun, Args} = CallbackMFA} when is_atom(Mod), is_atom(Fun), is_list(Args) ->
+            {undefined, CallbackMFA};
+            
+        {CallbackMod, _} when CallbackMod =/= undefined ->
+            error({badarg, "Cannot specify both callback_mod and callback_mfa"});
+            
+        {_, CallbackMFA} ->
+            error({badarg, [{callback_mfa, CallbackMFA}]})
+    end.
 
-    is_atom(CallbackMod)
-        orelse error({badarg, [{callback_mod, CallbackMod}]}),
 
-    bondy_mst_utils:implements_behaviour(CallbackMod, ?MODULE)
-        orelse error(
-            io_lib:format(
-                "Expected ~p to implement behaviour ~p",
-                [CallbackMod, ?MODULE]
-            )
-        ),
-    CallbackMod.
+%% @private
+call_callback(#?MODULE{callback_mod = CallbackMod, callback_mfa = undefined}, Function, Args) 
+        when CallbackMod =/= undefined ->
+    erlang:apply(CallbackMod, Function, Args);
+
+call_callback(#?MODULE{callback_mod = undefined, callback_mfa = {Mod, Fun, ExtraArgs}}, _Function, Args) ->
+    erlang:apply(Mod, Fun, ExtraArgs ++ Args);
+
+call_callback(CRDT, Function, _Args) ->
+    error({invalid_callback_configuration, CRDT#?MODULE.callback_mod, CRDT#?MODULE.callback_mfa, Function}).
 
 
 %% @private
@@ -906,7 +934,7 @@ maybe_broadcast(CRDT0, Gossip) ->
 
 %% @private
 broadcast(CRDT0, Gossip) ->
-    case (CRDT0#?MODULE.callback_mod):broadcast(Gossip) of
+    case call_callback(CRDT0, broadcast, [Gossip]) of
         ok ->
             telemetry:execute(
                 [bondy_mst, broadcast, sent],
@@ -1037,7 +1065,7 @@ merge(CRDT0, Peer) ->
                 root = Root,
                 set = MissingSet
             },
-            ok = (CRDT0#?MODULE.callback_mod):send(Peer, Cmd),
+            ok = call_callback(CRDT0, send, [Peer, Cmd]),
             CRDT0
     end.
 
@@ -1078,7 +1106,7 @@ do_merge(CRDT0, Peer, PeerRoot) ->
                         key = undefined,
                         value = undefined
                     },
-                    (CRDT#?MODULE.callback_mod):send(Peer, Event);
+                    call_callback(CRDT, send, [Peer, Event]);
 
                 false ->
                     ok
@@ -1100,13 +1128,21 @@ on_merge(CRDT0, Peer) ->
     CRDT = broadcast_pending(CRDT0),
 
     try
-        bondy_mst_utils:apply_lazy(
-            CRDT#?MODULE.callback_mod,
-            on_merge,
-            1,
-            [Peer],
-            fun() -> ok end
-        )
+        case {CRDT#?MODULE.callback_mod, CRDT#?MODULE.callback_mfa} of
+            {undefined, undefined} ->
+                ok;
+            {CallbackMod, undefined} when CallbackMod =/= undefined ->
+                bondy_mst_utils:apply_lazy(
+                    CallbackMod,
+                    on_merge,
+                    1,
+                    [Peer],
+                    fun() -> ok end
+                );
+            {undefined, {Mod, Fun, ExtraArgs}} ->
+                %% For callback_mfa, call the function with extra args + [on_merge, [Peer]]
+                erlang:apply(Mod, Fun, ExtraArgs ++ [on_merge, [Peer]])
+        end
     catch
         Class:Reason:Stacktrace ->
             ?LOG_ERROR(#{

--- a/src/bondy_mst_crdt.erl
+++ b/src/bondy_mst_crdt.erl
@@ -114,8 +114,8 @@ following callbacks:
 -record(?MODULE, {
     %% Normally node() but it can be a binary when testing
     node_id                         ::  node_id(),
-    callback_mod                    ::  module() | undefined,
-    callback_mfa                    ::  {module(), atom(), list()} | undefined,
+    callback_mod                    ::  module(),
+    callback_args                   ::  list(),
     tree                            ::  bondy_mst:t(),
     consistency_model               ::  consistency_model(),
     %% Set it to false if you are using a peer service that handles gossip
@@ -192,7 +192,7 @@ following callbacks:
                                 | {max_merges, pos_integer()}
                                 | {max_merges_per_root, pos_integer()}
                                 | {callback_mod, module()}
-                                | {callback_mfa, {module(), atom(), list()}}.
+                                | {callback_args, list()}.
 -type opts_map()            ::  #{
                                 %% bondy_mst
                                 store => bondy_mst_store:t(),
@@ -204,7 +204,7 @@ following callbacks:
                                 max_merges => pos_integer(),
                                 max_merges_per_root => pos_integer(),
                                 callback_mod => module(),
-                                callback_mfa => {module(), atom(), list()}
+                                callback_args => list()
                             }.
 -type gossip()              ::  #gossip{}.
 -type get_cmd()             ::  #get{}.
@@ -348,7 +348,12 @@ Called when a merge exchange has finished.
 """).
 -callback on_merge(Peer :: node_id()) -> ok.
 
--optional_callbacks([on_merge/1]).
+%% Extended callbacks (when using callback_args)
+-callback send(ExtraArg :: term(), Peer :: node_id(), message()) -> ok | {error, any()}.
+-callback broadcast(ExtraArg :: term(), Gossip :: gossip()) -> ok | {error, any()}.
+-callback on_merge(ExtraArg :: term(), Peer :: node_id()) -> ok.
+
+-optional_callbacks([on_merge/1, send/3, broadcast/2, on_merge/2]).
 
 
 
@@ -367,7 +372,7 @@ values of a key. See `bondy_mst:merger()`
 * `comparator => bondy_mst:comparator()` - the function used by the tree to
 compare keys for sorting. See `bondy_mst:comparator()`
 * `callback_mod => module()` - The module implementing this modules' callbacks
-* `callback_mfa => {module(), atom(), list()}` - Alternative to callback_mod, specifies module, function, and extra arguments. The function will be called with the extra arguments plus the callback-specific arguments
+* `callback_args => list()` - Optional extra arguments to be passed to all callback functions
 * `consistency_model => causal | eventual` - if `causal`, a full merge will be
 done on each update. If `eventual` full merges will only occur then triggered
 via `trigger/2`. Default is `causal`
@@ -400,14 +405,14 @@ new(NodeId, Opts0) when
 
     %% Configure the grove
     Opts = maps:with(
-        [callback_mod, callback_mfa, max_merges, max_merges_per_root], Opts0
+        [callback_mod, callback_args, max_merges, max_merges_per_root], Opts0
     ),
 
-    {CallbackMod, CallbackMFA} = validate_callback(Opts),
+    CallbackMod = validate_callback_mod(Opts),
     #?MODULE{
         node_id = NodeId,
         callback_mod = CallbackMod,
-        callback_mfa = CallbackMFA,
+        callback_args = key_value:get(callback_args, Opts, []),
         tree = Tree,
         consistency_model = key_value:get(consistency_model, Opts, causal),
         fwd_bcast = key_value:get(fwd_bcast, Opts, false),
@@ -861,42 +866,25 @@ handle(_CRDT, Msg) ->
 
 
 %% @private
-validate_callback(Opts) ->
-    case {maps:get(callback_mod, Opts, undefined), maps:get(callback_mfa, Opts, undefined)} of
-        {undefined, undefined} ->
-            error({badarg, "Either callback_mod or callback_mfa must be provided"});
-            
-        {CallbackMod, undefined} when is_atom(CallbackMod) ->
-            bondy_mst_utils:implements_behaviour(CallbackMod, ?MODULE)
-                orelse error(
-                    io_lib:format(
-                        "Expected ~p to implement behaviour ~p",
-                        [CallbackMod, ?MODULE]
-                    )
-                ),
-            {CallbackMod, undefined};
-            
-        {undefined, {Mod, Fun, Args} = CallbackMFA} when is_atom(Mod), is_atom(Fun), is_list(Args) ->
-            {undefined, CallbackMFA};
-            
-        {CallbackMod, _} when CallbackMod =/= undefined ->
-            error({badarg, "Cannot specify both callback_mod and callback_mfa"});
-            
-        {_, CallbackMFA} ->
-            error({badarg, [{callback_mfa, CallbackMFA}]})
-    end.
+validate_callback_mod(Opts) ->
+    CallbackMod = maps:get(callback_mod, Opts),
+
+    is_atom(CallbackMod)
+        orelse error({badarg, [{callback_mod, CallbackMod}]}),
+
+    bondy_mst_utils:implements_behaviour(CallbackMod, ?MODULE)
+        orelse error(
+            io_lib:format(
+                "Expected ~p to implement behaviour ~p",
+                [CallbackMod, ?MODULE]
+            )
+        ),
+    CallbackMod.
 
 
 %% @private
-call_callback(#?MODULE{callback_mod = CallbackMod, callback_mfa = undefined}, Function, Args) 
-        when CallbackMod =/= undefined ->
-    erlang:apply(CallbackMod, Function, Args);
-
-call_callback(#?MODULE{callback_mod = undefined, callback_mfa = {Mod, Fun, ExtraArgs}}, Function, Args) ->
-    erlang:apply(Mod, Fun, ExtraArgs ++ [Function, Args]);
-
-call_callback(CRDT, Function, _Args) ->
-    error({invalid_callback_configuration, CRDT#?MODULE.callback_mod, CRDT#?MODULE.callback_mfa, Function}).
+call_callback(#?MODULE{callback_mod = CallbackMod, callback_args = ExtraArgs}, Function, Args) ->
+    erlang:apply(CallbackMod, Function, ExtraArgs ++ Args).
 
 
 %% @private
@@ -1128,21 +1116,13 @@ on_merge(CRDT0, Peer) ->
     CRDT = broadcast_pending(CRDT0),
 
     try
-        case {CRDT#?MODULE.callback_mod, CRDT#?MODULE.callback_mfa} of
-            {undefined, undefined} ->
-                ok;
-            {CallbackMod, undefined} when CallbackMod =/= undefined ->
-                bondy_mst_utils:apply_lazy(
-                    CallbackMod,
-                    on_merge,
-                    1,
-                    [Peer],
-                    fun() -> ok end
-                );
-            {undefined, {Mod, Fun, ExtraArgs}} ->
-                %% For callback_mfa, call the function with extra args + [on_merge, [Peer]]
-                erlang:apply(Mod, Fun, ExtraArgs ++ [on_merge, [Peer]])
-        end
+        bondy_mst_utils:apply_lazy(
+            CRDT#?MODULE.callback_mod,
+            on_merge,
+            1,
+            CRDT#?MODULE.callback_args ++ [Peer],
+            fun() -> ok end
+        )
     catch
         Class:Reason:Stacktrace ->
             ?LOG_ERROR(#{

--- a/src/bondy_mst_crdt.erl
+++ b/src/bondy_mst_crdt.erl
@@ -892,8 +892,8 @@ call_callback(#?MODULE{callback_mod = CallbackMod, callback_mfa = undefined}, Fu
         when CallbackMod =/= undefined ->
     erlang:apply(CallbackMod, Function, Args);
 
-call_callback(#?MODULE{callback_mod = undefined, callback_mfa = {Mod, Fun, ExtraArgs}}, _Function, Args) ->
-    erlang:apply(Mod, Fun, ExtraArgs ++ Args);
+call_callback(#?MODULE{callback_mod = undefined, callback_mfa = {Mod, Fun, ExtraArgs}}, Function, Args) ->
+    erlang:apply(Mod, Fun, ExtraArgs ++ [Function, Args]);
 
 call_callback(CRDT, Function, _Args) ->
     error({invalid_callback_configuration, CRDT#?MODULE.callback_mod, CRDT#?MODULE.callback_mfa, Function}).


### PR DESCRIPTION
- Added `callback_mfa` field to the record alongside existing `callback_mod`
- Updated type definitions to include callback_mfa => {module(), atom(), list()}
- Implemented validate_callback/1 function that handles both patterns
- Added call_callback/3 helper function that routes calls appropriately:
    - For callback_mod: calls Module:Function(Args)
    - For callback_mfa: calls Module:Fun(ExtraArgs ++ [Function, Args])
- Updated all callback invocations (send, broadcast, on_merge) to use the new pattern
- Maintained full backward compatibility